### PR TITLE
Use `CSV.printheader()` instead of `CSV.write()`

### DIFF
--- a/src/DeIdentification.jl
+++ b/src/DeIdentification.jl
@@ -65,16 +65,13 @@ function deid_file!(dicts::DeIdDicts, fc::FileConfig, pc::ProjectConfig, logger)
         end
     end
 
-    schema = Tables.Schema(new_names, new_types)
-
-
     Memento.info(logger, "$(Dates.now()) Checking for primary column")
     @assert pk==true "Primary ID must be present in file"
 
-    # write header to file
-    CSV.write(schema, [], outfile)
-
-    open(outfile, "a") do io
+    open(outfile, "w") do io
+        # write header to file
+        CSV.printheader(
+            io, [string(n) for n in new_names], ",", '"', '"', '"', '\n')
 
         # Process each row
         for row in infile


### PR DESCRIPTION
CSV.jl was updated so that `CSV.write()` takes new parameters. In the process, `CSV.printheader()` was added. Since we were only calling `CSV.write()` to print the header line, it seems logical to use that
method instead.