### PR TITLE
Update DeIdentification.jl to support Windows

### DIFF
--- a/src/DeIdentification.jl
+++ b/src/DeIdentification.jl
@@ -18,6 +18,7 @@ using REPL.TerminalMenus
 include("config_builder.jl")
 include("de_identify.jl")
 include("exporting.jl")
+include("utils.jl")
 
 """
     deid_file!(dicts, file_config, project_config, logger)
@@ -30,7 +31,7 @@ function deid_file!(dicts::DeIdDicts, fc::FileConfig, pc::ProjectConfig, logger)
 
     # Initiate new file
     infile = CSV.File(fc.filename, dateformat = pc.dateformat)
-    outfile = joinpath(pc.outdir, "deid_" * fc.name * "_" * string(Dates.now()) * ".csv")
+    outfile = joinpath(pc.outdir, "deid_" * fc.name * "_" * getcurrentdate() * ".csv")
 
     ncol = length(infile.names)
     lastcol = infile.names[end]

--- a/src/exporting.jl
+++ b/src/exporting.jl
@@ -7,15 +7,17 @@ files are written to the  `output_path` specified in the configuration YAML.
 """
 function write_dicts(deid::DeIdDicts, logger, outdir)
 
-    idfile = joinpath(outdir, "id_dicts_" * string(Dates.now()) * ".json")
+    currentdate = getcurrentdate()
+
+    idfile = joinpath(outdir, "id_dicts_" * currentdate * ".json")
     Memento.info(logger, "$(Dates.now()) Writing ID dictionaries to $(idfile)")
     write(idfile, JSON.Writer.json(deid.id, 4))
 
-    dateshift_file = joinpath(outdir, "dateshifts_" * string(Dates.now()) * ".json")
+    dateshift_file = joinpath(outdir, "dateshifts_" * currentdate * ".json")
     Memento.info(logger, "$(Dates.now()) Writing dateshift values to $(dateshift_file)")
     write(dateshift_file, JSON.Writer.json(deid.dateshift, 4))
 
-    saltfile = joinpath(outdir, "salts_" * string(Dates.now()) * ".json")
+    saltfile = joinpath(outdir, "salts_" * currentdate * ".json")
     Memento.info(logger, "$(Dates.now()) Writing salt values to $(saltfile)")
     write(saltfile, JSON.Writer.json(deid.salt, 4))
 

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1,0 +1,10 @@
+"""
+	getcurrentdate()
+
+Returns the current date as a string conforming to ISO8601 _basic_ format.
+
+This is used to generate filenames in a cross-platform compatible way.
+"""
+function getcurrentdate()
+	return Dates.format(Dates.now(), "yyyymmddHHMMSS")
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -15,8 +15,8 @@ outputpath = joinpath(@__DIR__, "output")
 isdir(logpath) && rm(logpath, recursive=true)
 isdir(outputpath) && rm(outputpath, recursive=true)
 
-mkdir(joinpath(@__DIR__, "logs"))
-mkdir(joinpath(@__DIR__, "output"))
+mkdir(logpath)
+mkdir(outputpath)
 # ----------------------------
 
 @testset "config creation" begin
@@ -102,7 +102,7 @@ end
 
     # test that when config has glob pattern in file name, ProjectConfig gets all files in directory.
     @test length(proj_config_batch.file_configs) == 9
-    @test split(proj_config_batch.file_configs[3].filename, "/")[end] == "dx_2.csv"
+    @test split(proj_config_batch.file_configs[3].filename, Sys.iswindows() ? "\\" : "/")[end] == "dx_2.csv"
 end
 
 @testset "primary identifiter" begin
@@ -124,6 +124,13 @@ end
 end
 
 # TEAR DOWN
-rm(logpath, recursive=true)
-rm(outputpath, recursive=true)
+try
+    rm(logpath, recursive=true, force=true)
+catch e
+end
+
+try
+    rm(outputpath, recursive=true, force=true)
+catch e
+end
 # --------------------------


### PR DESCRIPTION
In particular, output files are named using a YYYYMMDDhhmmss string rather than the full ISO-8601 extended (YYYY-MM-DDThh:mm:ss) as `:` cannot be used in a file name on Windows. (I think this may also be a good idea on Macs where `:` is a special character in some filesystem uses).